### PR TITLE
moved installation of ROS1 for pepper to single isolated installation directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@ cmake_install.cmake
 install_manifest.txt
 compile_commands.json
 CTestTestfile.cmake
+*_ws/
+Python-*
+*_sources/
+.ros-root/

--- a/README.md
+++ b/README.md
@@ -67,19 +67,7 @@ We're going to copy these to the robot, assuming that your robot is connected to
 *Make sure you copy Python to the directory Python-2.7.13, without -pepper*
 
 ```
-$ scp -r Python-2.7.13-pepper nao@IP\_ADDRESS\_OF\_YOUR\_ROBOT:/home/nao/Python-2.7.13
-```
-
-```
-$ scp -r ros1\_dependencies nao@IP\_ADDRESS\_OF\_YOUR\_ROBOT:/home/nao/ros1\_dependencies
-```
-
-```
-$ scp -r pepper\_ros1\_ws nao@IP\_ADDRESS\_OF\_YOUR\_ROBOT:/home/nao/pepper\_ros1\_ws
-```
-
-```
-$ scp setup\_ros1\_pepper.bash
+$ scp -r .ros-root nao@IP\_ADDRESS\_OF\_YOUR\_ROBOT:.ros-root
 ```
 
 ### Run ROS from within Pepper
@@ -95,7 +83,7 @@ $ ssh nao@IP\_ADDRESS\_OF\_YOUR\_ROBOT
 *Source (not run) the setup script*
 
 ```
-$ source setup\_ros1\_pepper.bash
+$ source .ros-root/setup\_ros1\_pepper.bash
 ```
 
 *Start naoqi_driver, note that NETWORK\_INTERFACE may be either wlan0 or eth0, pick the appropriate interface if your robot is connected via wifi or ethernet*

--- a/build_ros1.sh
+++ b/build_ros1.sh
@@ -66,3 +66,4 @@ docker run -it --rm \
            -DCMAKE_PREFIX_PATH=\"/home/nao/${INSTALL_ROOT}/ros1_inst\" \
            -DCMAKE_FIND_ROOT_PATH=\"/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}-pepper;/home/nao/${INSTALL_ROOT}/ros1_dependencies;/home/nao/${INSTALL_ROOT}/ros1_inst;/home/nao/ctc\" \
            "
+cp ${PWD}/setup_ros1_pepper.bash ${PWD}/${INSTALL_ROOT}/setup_ros1_pepper.bash

--- a/build_ros1.sh
+++ b/build_ros1.sh
@@ -10,6 +10,8 @@ PYTHON3_PATCH_VERSION=1
 PYTHON2_VERSION=${PYTHON2_MAJOR_VERSION}.${PYTHON2_MINOR_VERSION}.${PYTHON2_PATCH_VERSION}
 PYTHON3_VERSION=${PYTHON3_MAJOR_VERSION}.${PYTHON3_MINOR_VERSION}.${PYTHON3_PATCH_VERSION}
 
+INSTALL_ROOT=.ros-root
+
 set -euf -o pipefail
 set -xv
 
@@ -20,43 +22,47 @@ fi
 
 mkdir -p pepper_ros1_ws/cmake
 mkdir -p pepper_ros1_ws/src
+mkdir -p ${INSTALL_ROOT}/ros1_inst
+
 cp pepper_ros1.repos pepper_ros1_ws/
 cp ctc-cmake-toolchain.cmake pepper_ros1_ws/
 cp cmake/eigen3-config.cmake pepper_ros1_ws/cmake/
 
 docker run -it --rm \
+  -u $(id -u $USER) \
   -e PYTHON2_VERSION=${PYTHON2_VERSION} \
   -e PYTHON2_MAJOR_VERSION=${PYTHON2_MAJOR_VERSION} \
   -e PYTHON2_MINOR_VERSION=${PYTHON2_MINOR_VERSION} \
   -e PYTHON3_VERSION=${PYTHON3_VERSION} \
   -e ALDE_CTC_CROSS=/home/nao/ctc \
-  -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/Python-${PYTHON2_VERSION}:ro \
+  -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}:ro \
   -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/Python-${PYTHON2_VERSION}-host:ro \
-  -v ${PWD}/Python-${PYTHON2_VERSION}-pepper:/home/nao/Python-${PYTHON2_VERSION}-pepper:ro \
-  -v ${PWD}/Python-${PYTHON3_VERSION}-host:/home/nao/Python-${PYTHON3_VERSION}:ro \
+  -v ${PWD}/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}-pepper:ro \
+  -v ${PWD}/Python-${PYTHON3_VERSION}-host:/home/nao/${INSTALL_ROOT}/Python-${PYTHON3_VERSION}:ro \
   -v ${PWD}/Python-${PYTHON3_VERSION}-host:/home/nao/Python-${PYTHON3_VERSION}-host:ro \
-  -v ${PWD}/Python-${PYTHON3_VERSION}-pepper:/home/nao/Python-${PYTHON3_VERSION}-pepper:ro \
+  -v ${PWD}/${INSTALL_ROOT}/Python-${PYTHON3_VERSION}:/home/nao/${INSTALL_ROOT}/Python-${PYTHON3_VERSION}-pepper:ro \
   -v ${ALDE_CTC_CROSS}:/home/nao/ctc:ro \
-  -v ${PWD}/ros1_dependencies:/home/nao/ros1_dependencies:ro \
+  -v ${PWD}/${INSTALL_ROOT}/ros1_dependencies:/home/nao/${INSTALL_ROOT}/ros1_dependencies:ro \
+  -v ${PWD}/${INSTALL_ROOT}/ros1_inst:/home/nao/${INSTALL_ROOT}/ros1_inst:rw \
   -v ${PWD}/pepper_ros1_ws:/home/nao/pepper_ros1_ws \
   ros1-pepper \
   bash -c "\
-           export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/Python-${PYTHON2_VERSION}/lib && \
-           export PATH=/home/nao/Python-${PYTHON2_VERSION}/bin:$PATH && \
+           export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/lib && \
+           export PATH=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin:$PATH && \
            cd pepper_ros1_ws && \
            vcs import src < pepper_ros1.repos && \
            touch src/orocos_kinematics_dynamics/python_orocos_kdl/CATKIN_IGNORE && \
-           ./src/catkin/bin/catkin_make_isolated --install -DCMAKE_BUILD_TYPE=Release \
+           ./src/catkin/bin/catkin_make_isolated --install --install-space /home/nao/${INSTALL_ROOT}/ros1_inst -DCMAKE_BUILD_TYPE=Release \
            --cmake-args \
            -DWITH_QT=OFF \
            -DSETUPTOOLS_DEB_LAYOUT=OFF \
            -DCATKIN_ENABLE_TESTING=OFF \
            -DENABLE_TESTING=OFF \
-           -DPYTHON_EXECUTABLE=/home/nao/Python-${PYTHON2_VERSION}/bin/python \
-           -DPYTHON_LIBRARY=/home/nao/Python-${PYTHON2_VERSION}-pepper/lib/libpython${PYTHON2_MAJOR_VERSION}.${PYTHON2_MINOR_VERSION}.so \
+           -DPYTHON_EXECUTABLE=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/python \
+           -DPYTHON_LIBRARY=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}-pepper/lib/libpython${PYTHON2_MAJOR_VERSION}.${PYTHON2_MINOR_VERSION}.so \
            -DTHIRDPARTY=ON \
            -DCMAKE_TOOLCHAIN_FILE=/home/nao/pepper_ros1_ws/ctc-cmake-toolchain.cmake \
            -DALDE_CTC_CROSS=/home/nao/ctc \
-           -DCMAKE_PREFIX_PATH=\"/home/nao/pepper_ros1_ws/install_isolated\" \
-           -DCMAKE_FIND_ROOT_PATH=\"/home/nao/Python-${PYTHON2_VERSION}-pepper;/home/nao/ros1_dependencies;/home/nao/pepper_ros1_ws/install_isolated;/home/nao/ctc\" \
+           -DCMAKE_PREFIX_PATH=\"/home/nao/${INSTALL_ROOT}/ros1_inst\" \
+           -DCMAKE_FIND_ROOT_PATH=\"/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}-pepper;/home/nao/${INSTALL_ROOT}/ros1_dependencies;/home/nao/${INSTALL_ROOT}/ros1_inst;/home/nao/ctc\" \
            "

--- a/build_ros1_dependencies.sh
+++ b/build_ros1_dependencies.sh
@@ -10,6 +10,8 @@ PYTHON3_PATCH_VERSION=1
 PYTHON2_VERSION=${PYTHON2_MAJOR_VERSION}.${PYTHON2_MINOR_VERSION}.${PYTHON2_PATCH_VERSION}
 PYTHON3_VERSION=${PYTHON3_MAJOR_VERSION}.${PYTHON3_MINOR_VERSION}.${PYTHON3_PATCH_VERSION}
 
+INSTALL_ROOT=.ros-root
+
 set -euf -o pipefail
 set -xv
 
@@ -24,30 +26,31 @@ cp pepper_ros1.repos pepper_ros1_ws/
 cp ctc-cmake-toolchain.cmake pepper_ros1_ws/
 cp cmake/eigen3-config.cmake pepper_ros1_ws/cmake/
 
-mkdir -p ros1_dependencies
+mkdir -p ${INSTALL_ROOT}/ros1_dependencies
 mkdir -p ros1_dependencies_sources/src
 cp ros1_dependencies.repos ros1_dependencies_sources/
 
 docker run -it --rm \
+  -u $(id -u $USER) \
   -e PYTHON2_VERSION=${PYTHON2_VERSION} \
   -e ALDE_CTC_CROSS=/home/nao/ctc \
-  -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/Python-${PYTHON2_VERSION}:ro \
+  -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}:ro \
   -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/Python-${PYTHON2_VERSION}-host:ro \
-  -v ${PWD}/Python-${PYTHON2_VERSION}-pepper:/home/nao/Python-${PYTHON2_VERSION}-pepper:ro \
+  -v ${PWD}/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}-pepper:ro \
   -v ${ALDE_CTC_CROSS}:/home/nao/ctc:ro \
   -v ${PWD}/pepper_ros1_ws:/home/nao/pepper_ros1_ws:ro \
   -v ${PWD}/ros1_dependencies_sources:/home/nao/ros1_dependencies_sources:rw \
-  -v ${PWD}/ros1_dependencies:/home/nao/ros1_dependencies:rw \
+  -v ${PWD}/${INSTALL_ROOT}/ros1_dependencies:/home/nao/${INSTALL_ROOT}/ros1_dependencies:rw \
   ros1-pepper \
   bash -c "\
-        export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/Python-${PYTHON2_VERSION}-host/lib && \
-        export PATH=/home/nao/Python-${PYTHON2_VERSION}-host/bin:$PATH && \
+        export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/lib && \
+        export PATH=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin:$PATH && \
         cd /home/nao/ros1_dependencies_sources && \
         vcs import src < ros1_dependencies.repos && \
         mkdir -p /home/nao/ros1_dependencies_sources/build/console_bridge && \
         cd /home/nao/ros1_dependencies_sources/build/console_bridge && \
         cmake \
-        -DCMAKE_INSTALL_PREFIX=/home/nao/ros1_dependencies \
+        -DCMAKE_INSTALL_PREFIX=/home/nao/${INSTALL_ROOT}/ros1_dependencies \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_TOOLCHAIN_FILE=/home/nao/pepper_ros1_ws/ctc-cmake-toolchain.cmake \
         -DALDE_CTC_CROSS=/home/nao/ctc \
@@ -57,7 +60,7 @@ docker run -it --rm \
         cd /home/nao/ros1_dependencies_sources/build/poco && \
         cmake \
         -DWITH_QT=OFF \
-        -DCMAKE_INSTALL_PREFIX=/home/nao/ros1_dependencies \
+        -DCMAKE_INSTALL_PREFIX=/home/nao/${INSTALL_ROOT}/ros1_dependencies \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_TOOLCHAIN_FILE=/home/nao/pepper_ros1_ws/ctc-cmake-toolchain.cmake \
         -DALDE_CTC_CROSS=/home/nao/ctc \
@@ -66,7 +69,7 @@ docker run -it --rm \
         mkdir -p /home/nao/ros1_dependencies_sources/build/urdfdom_headers && \
         cd /home/nao/ros1_dependencies_sources/build/urdfdom_headers && \
         cmake \
-        -DCMAKE_INSTALL_PREFIX=/home/nao/ros1_dependencies \
+        -DCMAKE_INSTALL_PREFIX=/home/nao/${INSTALL_ROOT}/ros1_dependencies \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_TOOLCHAIN_FILE=/home/nao/pepper_ros1_ws/ctc-cmake-toolchain.cmake \
         -DALDE_CTC_CROSS=/home/nao/ctc \
@@ -75,20 +78,20 @@ docker run -it --rm \
         mkdir -p /home/nao/ros1_dependencies_sources/build/urdfdom && \
         cd /home/nao/ros1_dependencies_sources/build/urdfdom && \
         cmake \
-        -DCMAKE_INSTALL_PREFIX=/home/nao/ros1_dependencies \
+        -DCMAKE_INSTALL_PREFIX=/home/nao/${INSTALL_ROOT}/ros1_dependencies \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_TOOLCHAIN_FILE=/home/nao/pepper_ros1_ws/ctc-cmake-toolchain.cmake \
         -DALDE_CTC_CROSS=/home/nao/ctc \
-        -DCMAKE_FIND_ROOT_PATH=\"/home/nao/ros1_dependencies;/home/nao/ctc\" \
+        -DCMAKE_FIND_ROOT_PATH=\"/home/nao/${INSTALL_ROOT}/ros1_dependencies;/home/nao/ctc\" \
         ../../src/urdfdom && \
         make -j4 install && \
         mkdir -p /home/nao/ros1_dependencies_sources/build/tinyxml2 && \
         cd /home/nao/ros1_dependencies_sources/build/tinyxml2 && \
         cmake \
-        -DCMAKE_INSTALL_PREFIX=/home/nao/ros1_dependencies \
+        -DCMAKE_INSTALL_PREFIX=/home/nao/${INSTALL_ROOT}/ros1_dependencies \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_TOOLCHAIN_FILE=/home/nao/pepper_ros1_ws/ctc-cmake-toolchain.cmake \
         -DALDE_CTC_CROSS=/home/nao/ctc \
-        -DCMAKE_FIND_ROOT_PATH=\"/home/nao/ros1_dependencies;/home/nao/ctc\" \
+        -DCMAKE_FIND_ROOT_PATH=\"/home/nao/${INSTALL_ROOT}/ros1_dependencies;/home/nao/ctc\" \
         ../../src/tinyxml2 && \
         make -j4 install"

--- a/docker/Dockerfile_ros1
+++ b/docker/Dockerfile_ros1
@@ -9,7 +9,7 @@ ENV LANG en_US.UTF-8
 RUN apt-get install -y --no-install-recommends lsb-release software-properties-common
 RUN apt-get install -y --no-install-recommends apt-transport-https
 RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends libc6-i386
 RUN apt-get install -y --no-install-recommends apt-transport-https

--- a/prepare_requirements_ros1.sh
+++ b/prepare_requirements_ros1.sh
@@ -6,6 +6,8 @@ set -xv
 
 PYTHON2_VERSION=2.7.13
 
+INSTALL_ROOT=.ros-root
+
 if [ -z "$ALDE_CTC_CROSS" ]; then
   echo "Please define the ALDE_CTC_CROSS variable with the path to Aldebaran's Crosscompiler toolchain"
   exit 1
@@ -19,41 +21,44 @@ if [ ! -e "Python-${PYTHON2_VERSION}.tar.xz" ]; then
 fi
 
 mkdir -p ${PWD}/Python-${PYTHON2_VERSION}-host
-mkdir -p ${PWD}/Python-${PYTHON2_VERSION}-pepper
+mkdir -p ${PWD}/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}
 
 docker run -it --rm \
+  -u $(id -u $USER) \
   -e PYTHON2_VERSION=${PYTHON2_VERSION} \
   -v ${PWD}/Python-${PYTHON2_VERSION}:/home/nao/Python-${PYTHON2_VERSION}-src \
-  -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/Python-${PYTHON2_VERSION} \
+  -v ${PWD}/Python-${PYTHON2_VERSION}-host:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION} \
   -v ${ALDE_CTC_CROSS}:/home/nao/ctc \
   ros1-pepper \
   bash -c "set -euf -o pipefail && \
            set -xv && \
+           ls -Z && \
            mkdir -p Python-${PYTHON2_VERSION}-src/build-host && \
            cd Python-${PYTHON2_VERSION}-src/build-host && \
-           export PATH=/home/nao/Python-${PYTHON2_VERSION}/bin:$PATH && \
+           export PATH=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin:$PATH && \
            ../configure \
-           --prefix=/home/nao/Python-${PYTHON2_VERSION} \
+           --prefix=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION} \
            --disable-ipv6 \
            ac_cv_file__dev_ptmx=yes \
            ac_cv_file__dev_ptc=no && \
-       export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/Python-${PYTHON2_VERSION}/lib && \
+       export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/lib && \
 		   make install && \
-       wget -O - -q https://bootstrap.pypa.io/get-pip.py | /home/nao/Python-${PYTHON2_VERSION}/bin/python && \
-       /home/nao/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool numpy rospkg defusedxml netifaces"
+       wget -O - -q https://bootstrap.pypa.io/get-pip.py | /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/python && \
+       /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool numpy rospkg defusedxml netifaces"
 
 docker run -it --rm \
+  -u $(id -u $USER) \
   -e PYTHON2_VERSION=${PYTHON2_VERSION} \
   -v ${PWD}/Python-${PYTHON2_VERSION}:/home/nao/Python-${PYTHON2_VERSION}-src \
-  -v ${PWD}/Python-${PYTHON2_VERSION}-pepper:/home/nao/Python-${PYTHON2_VERSION} \
+  -v ${PWD}/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION} \
   -v ${ALDE_CTC_CROSS}:/home/nao/ctc \
   ros1-pepper \
   bash -c "set -euf -o pipefail && \
            set -xv && \
            mkdir -p Python-${PYTHON2_VERSION}-src/build-pepper && \
            cd Python-${PYTHON2_VERSION}-src/build-pepper && \
-           export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/Python-${PYTHON2_VERSION}/lib && \
-           export PATH=/home/nao/Python-${PYTHON2_VERSION}/bin:$PATH && \
+           export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/lib && \
+           export PATH=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin:$PATH && \
            CC=/home/nao/ctc/bin/i686-aldebaran-linux-gnu-cc \
            CPP=/home/nao/ctc/bin/i686-aldebaran-linux-gnu-cpp \
            CXX=/home/nao/ctc/bin/i686-aldebaran-linux-gnu-c++ \
@@ -66,7 +71,7 @@ docker run -it --rm \
            CPPFLAGS='-I/home/nao/ctc/zlib/include -I/home/nao/ctc/bzip2/include -I/home/nao/ctc/openssl/include' \
            LDFLAGS='-L/home/nao/ctc/zlib/lib -L/home/nao/ctc/bzip2/lib -L/home/nao/ctc/openssl/lib' \
            ../configure \
-           --prefix=/home/nao/Python-${PYTHON2_VERSION} \
+           --prefix=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION} \
            --host=i686-aldebaran-linux-gnu \
            --build=x86_64-linux \
            --enable-shared \
@@ -74,5 +79,5 @@ docker run -it --rm \
            ac_cv_file__dev_ptmx=yes \
            ac_cv_file__dev_ptc=no && \
 		   make install && \
-       wget -O - -q https://bootstrap.pypa.io/get-pip.py | /home/nao/Python-${PYTHON2_VERSION}/bin/python && \
-       /home/nao/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool numpy rospkg defusedxml netifaces"
+       wget -O - -q https://bootstrap.pypa.io/get-pip.py | /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/python && \
+       /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool numpy rospkg defusedxml netifaces"

--- a/setup_ros1_pepper.bash
+++ b/setup_ros1_pepper.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-export PYTHONHOME="/home/nao/Python-2.7.13"
+export PYTHONHOME="/home/nao/.ros-root/Python-2.7.13"
 export PATH="${PYTHONHOME}/bin:${PATH}"
-export LD_LIBRARY_PATH="/home/nao/ros1_dependencies/lib:${PYTHONHOME}/lib:${LD_LIBRARY_PATH}"
+export LD_LIBRARY_PATH="/home/nao/.ros-root/ros1_dependencies/lib:${PYTHONHOME}/lib:${LD_LIBRARY_PATH}"
 
-source pepper_ros1_ws/install_isolated/setup.bash
+source /home/nao/.ros-root/ros1_inst/setup.bash


### PR DESCRIPTION
the ROS1 installation will now be installed in the following folder structure.
/
└home
  └nao
   └.ros-root
    ├ros1_inst
    ├ros1_dependencies
    ├setup_ros1_pepper.bash
    └Python-2.7.13
Minor (extra) changes:
- README has been updated to reflect these changes.
- Keyserver changed In the docker image to reflect an (for me) access-able one. 
- Updated gitignore to ignore (sub)workspaces and other build time files.