### PR TITLE
avoid ROS_PEPPER_CI: unbound variable error

### DIFF
--- a/build_ros1.sh
+++ b/build_ros1.sh
@@ -23,6 +23,7 @@ cp repos/pepper_ros1.repos pepper_ros1_ws/
 cp ctc-cmake-toolchain.cmake pepper_ros1_ws/
 cp cmake/eigen3-config.cmake pepper_ros1_ws/cmake/
 
+ROS_PEPPER_CI=${ROS_PEPPER_CI:=}
 USE_TTY=""
 if [ -z "$ROS_PEPPER_CI" ]; then
   USE_TTY="-it"

--- a/build_ros1_dependencies.sh
+++ b/build_ros1_dependencies.sh
@@ -30,6 +30,7 @@ mkdir -p ${INSTALL_ROOT}/ros1_dependencies
 mkdir -p ros1_dependencies_sources/src
 cp repos/ros1_dependencies.repos ros1_dependencies_sources/
 
+ROS_PEPPER_CI=${ROS_PEPPER_CI:=}
 USE_TTY=""
 if [ -z "$ROS_PEPPER_CI" ]; then
   USE_TTY="-it"


### PR DESCRIPTION
build_ros1_dependencies.sh fails becuase of unset bariable.
This change set empty ROS_PEPPER_CI if it is not defiend by user

$ ./build_ros1_dependencies.sh
./build_ros1_dependencies.sh: line 34: ROS_PEPPER_CI: unbound variable