### PR TITLE
update get-pip.py location

### DIFF
--- a/prepare_requirements_ros1.sh
+++ b/prepare_requirements_ros1.sh
@@ -60,8 +60,8 @@ docker run ${USE_TTY} --rm \
       ac_cv_file__dev_ptc=no && \
     export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/lib && \
     make -j4 install && \
-    wget -O - -q https://bootstrap.pypa.io/get-pip.py | /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/python && \
-    /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool numpy rospkg defusedxml netifaces"
+    wget -O - -q https://bootstrap.pypa.io/pip/2.7/get-pip.py | /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/python && \
+    /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool==0.2.15 numpy rospkg defusedxml netifaces"
 
 docker run ${USE_TTY} --rm \
   -u $(id -u) \
@@ -91,5 +91,5 @@ docker run ${USE_TTY} --rm \
     export LD_LIBRARY_PATH=/home/nao/ctc/openssl/lib:/home/nao/ctc/zlib/lib:/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/lib && \
     export PATH=/home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin:\${PATH} && \
     make install && \
-    wget -O - -q https://bootstrap.pypa.io/get-pip.py | /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/python && \
-    /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool numpy rospkg defusedxml netifaces"
+    wget -O - -q https://bootstrap.pypa.io/pip/2.7/get-pip.py | /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/python && \
+    /home/nao/${INSTALL_ROOT}/Python-${PYTHON2_VERSION}/bin/pip install empy catkin-pkg setuptools vcstool==0.2.15 numpy rospkg defusedxml netifaces"


### PR DESCRIPTION
latest get-pip.py does not work on Python 2.7

```
This script does not work on Python 2.7 The minimum supported Python version is 3.6. Please use https://bootstrap.pypa.io/pip/2.7/get-pip.py instead.
```

use https://bootstrap.pypa.io/pip/2.7/get-pip.py, instead of https://bootstrap.pypa.io/get-pip.py