### PR TITLE
hkps.pool.sks-keyservers.net did not resspond, use snapshot.ros.rog

### DIFF
--- a/docker/Dockerfile_ros1
+++ b/docker/Dockerfile_ros1
@@ -8,8 +8,8 @@ RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 ENV LANG en_US.UTF-8
 RUN apt-get install -y --no-install-recommends lsb-release software-properties-common
 RUN apt-get install -y --no-install-recommends apt-transport-https
-RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
-RUN apt-key adv --keyserver hkps.pool.sks-keyservers.net --recv-keys 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN echo "deb http://snapshots.ros.org/kinetic/final/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/ros-latest.list
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 0xCBF125EA
 RUN apt-get update
 RUN apt-get install -y --no-install-recommends libc6-i386
 RUN apt-get install -y --no-install-recommends apt-transport-https


### PR DESCRIPTION
```
Step 11/36 : RUN echo "deb http://packages.ros.org/ros/ubuntu `lsb_release -cs` main" > /etc/a
pt/sources.list.d/ros-latest.list
 ---> Using cache
 ---> d8b86bef7142
Step 12/36 : RUN apt-key adv --keyserver hkps.pool.sks-keyservers.net --recv-keys 421C365BD9FF
1F717815A3895523BAEEB01FA116
 ---> Running in 8a68ac26499a
Executing: /tmp/tmp.114JD52bzl/gpg.1.sh --keyserver
hkps.pool.sks-keyservers.net
--recv-keys
421C365BD9FF1F717815A3895523BAEEB01FA116
gpg: requesting key B01FA116 from hkp server hkps.pool.sks-keyservers.net
```